### PR TITLE
Allow subclasses to hook into before/after render

### DIFF
--- a/txroutes/__init__.py
+++ b/txroutes/__init__.py
@@ -141,7 +141,7 @@ class Dispatcher(Resource):
             ):
 
         # First, run the _render_before handler for any pre-rendering actions.
-        # For eaxmple, you might use this to implement a plugin that sets
+        # For example, you might use this to implement a pre-filter that sets
         # CORS headers.
         try:
             if wrap:


### PR DESCRIPTION
This allows a subclass to safely implement code that executes additional handlers before or after a route-matched handler.  For example, this is useful for a subclass that wants to implement its own prefilter or plugin system.
