### PR TITLE
Python3 support

### DIFF
--- a/txroutes/__init__.py
+++ b/txroutes/__init__.py
@@ -181,7 +181,7 @@ class Dispatcher(Resource):
                 request.setResponseCode(500)
                 request.write(DEFAULT_500_HTML)
                 request.finish()
-        except Exception, e:
+        except Exception as e:
             self.__logger.exception(e)
 
 


### PR DESCRIPTION
A good way to test is to run python2.7 -3 <your test file> and make sure no warnings are coming from txroutes (there will likely still be warnings from twisted).
